### PR TITLE
Use relative symlink to dotnet binary

### DIFF
--- a/org.freedesktop.Sdk.Extension.dotnet5.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet5.yaml
@@ -32,7 +32,7 @@ modules:
     build-commands:
       - "mkdir -p /usr/lib/sdk/dotnet5/{bin,lib}"
       - "cp -r * /usr/lib/sdk/dotnet5/lib"
-      - "ln -s /usr/lib/sdk/dotnet5/lib/dotnet /usr/lib/sdk/dotnet5/bin/dotnet"
+      - "ln -s ../lib/dotnet /usr/lib/sdk/dotnet5/bin/dotnet"
     sources:
       - type: archive
         only-arches: [x86_64]


### PR DESCRIPTION
This allows using the symlink in flatpak apps, e.g. `/app/lib/sdk/dotnet5`